### PR TITLE
Adjustments to view loading inside modal

### DIFF
--- a/config/views.view.entityreference_view_widget_sample.json
+++ b/config/views.view.entityreference_view_widget_sample.json
@@ -71,7 +71,8 @@
               "operator": false
             }
           }
-        }
+        },
+        "use_ajax": true
       }
     },
     "entityreference_view_widget_1": {
@@ -84,7 +85,7 @@
         },
         "defaults": {
           "title": false,
-          "use_ajax": false,
+          "use_ajax": true,
           "style_plugin": false,
           "style_options": false,
           "row_plugin": false,

--- a/entityreference_view_widget.module
+++ b/entityreference_view_widget.module
@@ -244,13 +244,8 @@ function entityreference_view_widget_add_more_ajax($form, $form_state) {
       // Allow the alteration of Views arguments.
       backdrop_alter('entityreference_view_widget_views_arguments', $arguments, $form_state, $view);
 
-      if (!empty($arguments)) {
-        $view->set_arguments($arguments);
-      }
-
       $settings['cardinality'] = $settings['field']['cardinality'];
-      // Unset some values in order to keep a relatively small serialized
-      // string.
+      // Unset some values in order to keep a relatively small JSON string.
       unset($settings['field']);
       unset($settings['instance']);
 
@@ -264,7 +259,7 @@ function entityreference_view_widget_add_more_ajax($form, $form_state) {
       $settings = array(
         'entityReferenceViewWidget' => array(
           'settings' => $settings,
-          'serialized' => json_encode($settings),
+          'json' => json_encode($settings),
         ),
       );
       $commands[] = ajax_command_settings($settings, TRUE);
@@ -440,7 +435,7 @@ function entityreference_view_widget_ajax($form, $form_state) {
       // Automatically close the modal if necessary.
       if (!empty($widget_settings['close_modal'])) {
         backdrop_add_library('system', 'backdrop.ajax');
-        $commands[] = ajax_command_close_dialog('#entityreference-view-widget-modal');
+        $commands[] = ajax_command_close_modal_dialog();
       }
     }
   }

--- a/entityreference_view_widget.module
+++ b/entityreference_view_widget.module
@@ -233,9 +233,6 @@ function entityreference_view_widget_add_more_ajax($form, $form_state) {
     $target_view = explode('|', $settings['view']);
     $view = views_get_view($target_view[0]);
     if (!empty($view)) {
-      $view->set_display($target_view[1]);
-      $view->dom_id = $view->name . '-' . $target_view[1];
-      $view->display_handler->set_option('use_ajax', TRUE);
 
       _entityreference_view_widget_add_resources($form);
       $arguments = array();
@@ -270,8 +267,8 @@ function entityreference_view_widget_add_more_ajax($form, $form_state) {
           'serialized' => json_encode($settings),
         ),
       );
-      backdrop_add_js($settings, 'setting');
-      $commands[] = ajax_command_open_dialog('#entityreference-view-widget-modal', $modal_title, $view->preview());
+      $commands[] = ajax_command_settings($settings, TRUE);
+      $commands[] = ajax_command_open_dialog('#entityreference-view-widget-modal', $modal_title, $view->preview($target_view[1], $arguments));
     }
   }
   return array(

--- a/js/entityreference_view_widget.js
+++ b/js/entityreference_view_widget.js
@@ -81,8 +81,8 @@
 
         // We need to pass the settings via an hidden field because Views doesn't
         // allow us to pass data between ajax requests.
-        if (settings.entityReferenceViewWidget.serialized) {
-          $('input[name="ervw_settings"]').val(settings.entityReferenceViewWidget.serialized);
+        if (settings.entityReferenceViewWidget.json) {
+          $('input[name="ervw_settings"]').val(settings.entityReferenceViewWidget.json);
         }
       }
     }


### PR DESCRIPTION
- Switch to adding ajax settings using "ajax_command_settings"
- Add arguments to "$views->preview()" when loading view in modal
- Remove display set that was problematic for view in modal
- Remove enfocement of AJAX that depended on the display set (The view is still required to have ajax enabled to work)

Resolves #2